### PR TITLE
Allow code to visit function call groups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
           python-version: 3.11
       - name: Install Pip Dependencies
         run: pip install -r requirements.txt
+      - name: Install SpaCy models
+        run: python -m spacy download en_core_web_sm && python -m spacy download en_core_web_md
       - name: Run Tests
         run: coverage run -m pytest && coverage report -m
       - name: Coveralls

--- a/energyplus_refactor_helper/action.py
+++ b/energyplus_refactor_helper/action.py
@@ -264,11 +264,11 @@ class ErrorCallRefactor(RefactorBase):
                 if counter % 200 == 0:
                     logger.terminal_progress_bar(counter, expected_comparison_count, (i, j))
         logger.terminal_progress_done()
-        with open('/tmp/output.txt', 'w') as f:
-            for i, compare in enumerate(sorted(compares, key=lambda x: x[2], reverse=True)):
-                if i > 10000:
-                    break
-                f.write(f"{compare[0]} 😊 {compare[1]} 😊 {compare[2]}\n")
+        # with open('/tmp/output.txt', 'w') as f:
+        #     for i, compare in enumerate(sorted(compares, key=lambda x: x[2], reverse=True)):
+        #         if i > 10000:
+        #             break
+        #         f.write(f"{compare[0]} 😊 {compare[1]} 😊 {compare[2]}\n")
         source_folder.generate_reports(processed_source_files, output_path, skip_plots=skip_plots)
         if edit_in_place:
             source_folder.rewrite_files_in_place(processed_source_files, self.visitor, self.visits_each_group())

--- a/energyplus_refactor_helper/action.py
+++ b/energyplus_refactor_helper/action.py
@@ -3,6 +3,9 @@
 from pathlib import Path
 from typing import Type
 
+import spacy
+
+from energyplus_refactor_helper.logger import logger
 from energyplus_refactor_helper.source_folder import SourceFolder
 
 
@@ -67,7 +70,7 @@ class RefactorBase:
         return '\n'.join(individual_call_strings)
 
     # noinspection PyMethodMayBeStatic
-    def function_visitor(self, function_call_or_group) -> str:
+    def visitor(self, function_call_or_group) -> str:
         """
         This method will visit _either_ each function call, or each function call group, and generate a new string
         representation of that call or group.  The object passed in is determined by the visits_each_group() member
@@ -88,24 +91,26 @@ class RefactorBase:
     def visits_each_group(self) -> bool:
         return False
 
-    def run(self, source_repo: Path, output_path: Path, edit_in_place: bool) -> int:
+    def run(self, source_repo: Path, output_path: Path, edit_in_place: bool, skip_plots: bool) -> int:
         """
         This method performs the actual run operations based on input arguments.  The method calls (possibly overridden)
-        methods to get run data, then creates a SourceFolder instance, and returns a success flag with 0 if successful
-        and 1 if not.
+        methods to get run data, then creates a SourceFolder instance, performs operations, and returns a success flag
+        with 0 if successful and 1 if not.
 
         :param source_repo: The root of the EnergyPlus repository to operate upon.
         :param output_path: An output directory where logs and results should be dumped.
         :param edit_in_place: A flag for whether we are actually editing the repository files in place.  If not, then
                               this will mostly just result in analysis, with outputs in the output_path provided.
+        :param skip_plots: A flag for whether to skip plot generation, which can be time-consuming.
         :return: A status flag, 0 if successful, 1 if not.
         """
-        file_names_to_ignore = self.file_names_to_ignore()
-        source_path = self.analysis_root_from_repo_root(source_repo)
-        sf = SourceFolder(
-            source_path, output_path, file_names_to_ignore, self.function_calls(),
-            edit_in_place, self.visits_each_group(), self.function_visitor
-        )
+        root_path = self.analysis_root_from_repo_root(source_repo)
+        sf = SourceFolder(root_path, self.function_calls())
+        matched_source_files = sf.find_files(self.file_names_to_ignore())
+        processed_source_files = sf.analyze_source_files(matched_source_files)
+        sf.generate_reports(processed_source_files, output_path, skip_plots=skip_plots)
+        if edit_in_place:
+            sf.rewrite_files_in_place(processed_source_files, self.visitor, self.visits_each_group())
         return 0 if sf.success else 1
 
 
@@ -122,6 +127,13 @@ class ErrorCallRefactor(RefactorBase):
         :return: A list with a single object, a string UtilityRoutines.cc
         """
         return ['UtilityRoutines.cc']
+
+    class CallSymbols:
+        ShowFatalError = 0
+        ShowSevereError = 1
+        ShowSevereMessage = 2
+        ShowContinueError = 3
+        ShowWarningError = 6
 
     def function_calls(self) -> list[str]:
         """
@@ -142,7 +154,7 @@ class ErrorCallRefactor(RefactorBase):
             "ShowRecurringWarningErrorAtEnd",
             "ShowRecurringContinueErrorAtEnd",
             "StoreRecurringErrorMessage",
-            "ShowErrorMessage",
+            # "ShowErrorMessage",  not in the public interface anymore
             "SummarizeErrors",
             "ShowRecurringErrors",
             "ShowSevereDuplicateName",
@@ -156,7 +168,7 @@ class ErrorCallRefactor(RefactorBase):
             "ShowWarningItemNotFound"
         ]
 
-    def function_visitor(self, function_group) -> str:
+    def visitor(self, function_group) -> str:
         """
         For this action class, this function will be visited for each function call "group".  This function will assess
         the function group, looking for different ways to rewrite the group as a new string.  For right now, this will
@@ -169,11 +181,98 @@ class ErrorCallRefactor(RefactorBase):
         :param function_group: The FunctionCallGroup to inspect, and from that, generate a new string representation.
         :return: A string representation of the function call group.
         """
-        return RefactorBase.default_function_group_visitor(function_group)
+        if any([f.preceding_text != "" for f in function_group.function_calls]):
+            # if there is meaningful text in the group, outside the function calls themselves, just ignore this group
+            return RefactorBase.default_function_group_visitor(function_group)
+        else:
+            # get some convenience variables
+            one_liner = len(function_group.function_calls) == 1
+            first_call = function_group.function_calls[0]
+            last_call = function_group.function_calls[-1]
+            middle_calls = function_group.function_calls[1:-1]
+            # Look for specific opportunities to refactor.  Let's start with a severe + [N>=0 continue error] + fatal.
+            starts_with_fatal = first_call.call_type == self.CallSymbols.ShowFatalError
+            starts_with_severe = first_call.call_type == self.CallSymbols.ShowSevereError
+            starts_with_warning = first_call.call_type == self.CallSymbols.ShowWarningError
+            ends_with_fatal = last_call.call_type == self.CallSymbols.ShowFatalError
+            ends_with_continue = last_call.call_type == self.CallSymbols.ShowContinueError
+            if len(function_group.function_calls) <= 2:
+                valid_middle = True
+            else:
+                valid_middle = all([f.call_type == self.CallSymbols.ShowContinueError for f in middle_calls])
+            state = function_group.function_calls[0].parse_arguments()[0]
+            remaining_arguments = [f.parse_arguments()[1] for f in function_group.function_calls]
+            argument_one = function_group.function_calls[0].parse_arguments()[1]
+            argument_listing = "{" + ", ".join(remaining_arguments) + "}"
+            # regroup the errors into a single function call, with a default error code for now
+            if starts_with_severe and valid_middle and ends_with_fatal:
+                return f"emitErrorMessages({state}, -999, {argument_listing}, true);"
+            elif starts_with_severe and valid_middle and ends_with_continue:
+                return f"emitErrorMessages({state}, -999, {argument_listing}, false);"
+            elif starts_with_warning and valid_middle and ends_with_continue:
+                return f"emitWarningMessages({state}, -999, {argument_listing});"
+            elif one_liner and starts_with_warning:
+                return f"emitWarningMessage({state}, -999, {argument_one});"
+            elif one_liner and starts_with_severe:
+                return f"emitErrorMessage({state}, -999, {argument_one}, false);"
+            elif one_liner and starts_with_fatal:
+                return f"emitErrorMessage({state}, -999, {argument_one}, true);"
+            else:
+                return RefactorBase.default_function_group_visitor(function_group)
 
     # noinspection PyMethodMayBeStatic
     def visits_each_group(self) -> bool:
         return True
+
+    def run(self, source_repo: Path, output_path: Path, edit_in_place: bool, skip_plots: bool) -> int:
+        """This method performs the actual run operations based on input arguments for the error call action.
+        This is similar to the base class run() method, but with some specializations.  For example, this run() method
+        gathers the error calls into a special structure where we can find similarities and lookup meaningful grouping
+        information.
+
+        :param source_repo: The root of the EnergyPlus repository to operate upon.
+        :param output_path: An output directory where logs and results should be dumped.
+        :param edit_in_place: A flag for whether we are actually editing the repository files in place.  If not, then
+                              this will mostly just result in analysis, with outputs in the output_path provided.
+        :param skip_plots: A flag for whether to skip plot generation, which can be time-consuming.
+        :return: A status flag, 0 if successful, 1 if not.
+        """
+        root_path = self.analysis_root_from_repo_root(source_repo)
+        source_folder = SourceFolder(root_path, self.function_calls())
+        matched_source_files = source_folder.find_files(self.file_names_to_ignore())
+        processed_source_files = source_folder.analyze_source_files(matched_source_files)
+        error_message_texts = []
+        for source_file in processed_source_files:
+            for group in source_file.found_function_groups:
+                new_group_text = self.visitor(group)
+                error_message_texts.append(new_group_text.replace('\n', ' '))
+        nlp = spacy.load("en_core_web_md")
+        encounters = set()
+        compares = set()
+        docs = list(nlp.pipe(error_message_texts))
+        n = len(docs)
+        expected_comparison_count = (n * n - n) / 2
+        counter = 0
+        logger.log("About to determine text similarities between messages")
+        for i, d1 in enumerate(docs):
+            for j, d2 in enumerate(docs):
+                if i == j or (i, j) in encounters or (j, i) in encounters:
+                    continue
+                encounters.add((i, j))
+                compares.add((d1.text, d2.text, d1.similarity(d2)))
+                counter += 1
+                if counter % 200 == 0:
+                    logger.terminal_progress_bar(counter, expected_comparison_count, (i, j))
+        logger.terminal_progress_done()
+        with open('/tmp/output.txt', 'w') as f:
+            for i, compare in enumerate(sorted(compares, key=lambda x: x[2], reverse=True)):
+                if i > 10000:
+                    break
+                f.write(f"{compare[0]} 😊 {compare[1]} 😊 {compare[2]}\n")
+        source_folder.generate_reports(processed_source_files, output_path, skip_plots=skip_plots)
+        if edit_in_place:
+            source_folder.rewrite_files_in_place(processed_source_files, self.visitor, self.visits_each_group())
+        return 0 if source_folder.success else 1
 
 
 all_actions: dict[str, Type[RefactorBase]] = {

--- a/energyplus_refactor_helper/action.py
+++ b/energyplus_refactor_helper/action.py
@@ -60,8 +60,7 @@ class RefactorBase:
     def default_function_group_visitor(function_group) -> str:
         individual_call_strings = []
         for i, function in enumerate(function_group.function_calls):
-            args = ', '.join(function.parse_arguments())
-            full_call = f"{function.function_name}({args});"
+            full_call = function.rewrite()
             include_prefix = len(function_group.function_calls) > 0 and i > 0
             including_prefix = (function.preceding_text + full_call) if include_prefix else full_call
             individual_call_strings.append(including_prefix)

--- a/energyplus_refactor_helper/action.py
+++ b/energyplus_refactor_helper/action.py
@@ -45,6 +45,28 @@ class RefactorBase:
         """
         raise NotImplementedError()
 
+    @staticmethod
+    def default_function_call_visitor(function_call) -> str:
+        """
+        This is a small helper function that simply takes a function call argument, and rewrites it in a functionally
+        equivalent manner, returning that string.
+
+        :param function_call: The FunctionCall instance to operate on
+        ;return str: The function call in a functionally equivalent string
+        """
+        return function_call.rewrite()
+
+    @staticmethod
+    def default_function_group_visitor(function_group) -> str:
+        individual_call_strings = []
+        for i, function in enumerate(function_group.function_calls):
+            args = ', '.join(function.parse_arguments())
+            full_call = f"{function.function_name}({args});"
+            include_prefix = len(function_group.function_calls) > 0 and i > 0
+            including_prefix = (function.preceding_text + full_call) if include_prefix else full_call
+            individual_call_strings.append(including_prefix)
+        return '\n'.join(individual_call_strings)
+
     # noinspection PyMethodMayBeStatic
     def function_visitor(self, function_call_or_group) -> str:
         """
@@ -61,8 +83,7 @@ class RefactorBase:
                                        didn't break anything.
         :return: A string representation of the function call or function call group.
         """
-        args = ', '.join(function_call_or_group.parse_arguments())
-        return f"{function_call_or_group.function_name}({args});"
+        return RefactorBase.default_function_call_visitor(function_call_or_group)
 
     # noinspection PyMethodMayBeStatic
     def visits_each_group(self) -> bool:
@@ -149,14 +170,7 @@ class ErrorCallRefactor(RefactorBase):
         :param function_group: The FunctionCallGroup to inspect, and from that, generate a new string representation.
         :return: A string representation of the function call group.
         """
-        individual_call_strings = []
-        for i, function in enumerate(function_group.function_calls):
-            args = ', '.join(function.parse_arguments())
-            full_call = f"{function.function_name}({args});"
-            include_prefix = len(function_group.function_calls) > 0 and i > 0
-            including_prefix = (function.preceding_text + full_call) if include_prefix else full_call
-            individual_call_strings.append(including_prefix)
-        return '\n'.join(individual_call_strings)
+        return RefactorBase.default_function_group_visitor(function_group)
 
     # noinspection PyMethodMayBeStatic
     def visits_each_group(self) -> bool:

--- a/energyplus_refactor_helper/function_call.py
+++ b/energyplus_refactor_helper/function_call.py
@@ -161,3 +161,11 @@ class FunctionCall:
         """String representation summary of the function call"""
         single_line = ''.join(self.as_cleaned_multiline()).strip()
         return f"{self.starting_line_number} - {self.ending_line_number} : {single_line[:35]}"
+
+    def rewrite(self) -> str:
+        """
+        Rewrite the function call as a string, functionally equivalent to the original form, but modified with
+        line breaks and such missing.
+        """
+        args = ', '.join(self.parse_arguments())
+        return f"{self.function_name}({args});"

--- a/energyplus_refactor_helper/function_call.py
+++ b/energyplus_refactor_helper/function_call.py
@@ -31,7 +31,7 @@ class FunctionCall:
         self.starting_line_number = line_start
         self.ending_line_number = line_start  # initialize here
         self.char_start_in_file = file_start_index
-        self.preceding_text = first_line_text[0:line_start_index]
+        self.preceding_text = first_line_text[0:line_start_index].strip()
         self.char_start_first_line = line_start_index
         self.char_end_in_file = -1
         self.appears_successful = True

--- a/energyplus_refactor_helper/function_call.py
+++ b/energyplus_refactor_helper/function_call.py
@@ -31,6 +31,7 @@ class FunctionCall:
         self.starting_line_number = line_start
         self.ending_line_number = line_start  # initialize here
         self.char_start_in_file = file_start_index
+        self.preceding_text = first_line_text[0:line_start_index]
         self.char_start_first_line = line_start_index
         self.char_end_in_file = -1
         self.appears_successful = True
@@ -70,22 +71,6 @@ class FunctionCall:
             this_line_content = t[self.char_start_first_line:].strip() if i == 0 else t.strip()
             skip_first_line_to_call_start.append(this_line_content)
         return [x.strip() for x in skip_first_line_to_call_start]
-
-    def as_new_version(self) -> str:
-        """
-        This function will provide the modified version of a single function call.  Right now this
-        function simply rewrites the function call as a single line with no functional change.
-        The advantage of this is that we can verify our parsing by simply rewriting all function calls
-        in the source code, reapplying Clang Format, and making sure we didn't break anything.
-        In the future, this function will utilize action-specific functionality to manipulate the
-        function call in more meaningful ways.  There will likely be a callback function on the
-        action/Refactor class that takes a function name and argument list and returns the modified
-        version.
-
-        :return: A string representation of the function call after changes have been applied.
-        """
-        args = ', '.join(self.parse_arguments())
-        return f"{self.function_name}({args});"
 
     def parse_arguments(self) -> list[str]:
         """
@@ -171,12 +156,6 @@ class FunctionCall:
             else:
                 current_arg += c
         return [a.strip() for a in args]
-
-    def summary(self) -> dict:
-        return {
-            'type': self.call_type, 'line_start': self.starting_line_number,
-            'line_end': self.ending_line_number, 'args': self.parse_arguments()
-        }
 
     def __str__(self):
         """String representation summary of the function call"""

--- a/energyplus_refactor_helper/function_call_group.py
+++ b/energyplus_refactor_helper/function_call_group.py
@@ -31,12 +31,12 @@ class FunctionCallGroup:
         :return: A single dictionary summary.
         """
         num_calls_in_this_chunk = len(self.function_calls)
-        call_types = [e['type'] for e in self.function_calls]
+        call_types = [e.call_type for e in self.function_calls]
         cleaned_call_types = [i[0] for i in groupby(call_types)]  # remove duplicates
-        chunk_start_line = self.function_calls[0]['line_start']
-        chunk_end_line = self.function_calls[-1]['line_end']
+        chunk_start_line = self.function_calls[0].starting_line_number
+        chunk_end_line = self.function_calls[-1].ending_line_number
         try:
-            concatenated_messages = ' *** '.join([e['args'][1] for e in self.function_calls])
+            concatenated_messages = ' *** '.join([e.parse_arguments()[1] for e in self.function_calls])
         except IndexError:  # pragma: no cover
             # this is almost certainly indicative of a parser problem, so we can't cover it
             raise Exception(f"Something went wrong with the arg processing for this chunk! {self.function_calls}")
@@ -50,4 +50,4 @@ class FunctionCallGroup:
         }
 
     def to_json(self) -> dict:
-        return {'summary': self.summary_dict(), 'original': self.function_calls}
+        return {'summary': self.summary_dict(), 'original': [str(f) for f in self.function_calls]}

--- a/energyplus_refactor_helper/function_call_group.py
+++ b/energyplus_refactor_helper/function_call_group.py
@@ -11,7 +11,7 @@ class FunctionCallGroup:
         a list of function call instances, but some extra intelligence can apply specifically to a group of calls.
         so a class is here to provide that context.
         """
-        self.function_calls = []
+        self.function_calls: list[FunctionCall] = []
         self.started = False
         if initial_call:
             self.add_function_call(initial_call)

--- a/energyplus_refactor_helper/main.py
+++ b/energyplus_refactor_helper/main.py
@@ -45,12 +45,18 @@ def run(args: list[str]) -> int:
         default=False,
         help='If True, make changes in place in the source directory'
     )
+    parser.add_argument(
+        '--skip-plots', '-s',
+        action='store_true',
+        default=False,
+        help='If True, skip making the plot, which can take a long time'
+    )
     args = parser.parse_args(args=args)
     source_repo = Path(args.source_repository)
     output_path = Path(args.output_directory)
     action_class = all_actions[args.action_to_run]
     action_instance = action_class()
-    return action_instance.run(source_repo, output_path, args.in_place)
+    return action_instance.run(source_repo, output_path, args.in_place, args.skip_plots)
 
 
 def run_cli() -> int:  # pragma: no cover

--- a/energyplus_refactor_helper/source_file.py
+++ b/energyplus_refactor_helper/source_file.py
@@ -6,17 +6,27 @@ from energyplus_refactor_helper.function_call import FunctionCall
 
 
 class SourceFile:
-    """
-    This class represents a single source code file, processing it to find all matching function calls, and
-    providing functionality to refactor them into a new form automatically.
-    """
 
-    def __init__(self, path: Path, function_call_list: list[str]):
+    def __init__(self, path: Path, function_calls: list[str], group_flag: bool, visitor):
+        """
+        This class represents a single source code file, processing it to find all matching function calls, and
+        providing functionality to refactor them into a new form automatically.
+
+        :param path: The Path instance pointing to this source file
+        :param function_calls: The list of function calls currently being searched
+        :param group_flag: A flag indicating whether the action will operate on groups of function calls (if True)
+                                 or individual function calls (if False)
+        :param visitor: A callable function that takes either a FunctionCall or a FunctionCallInstance and returns a
+                        string.  The type should depend on the group_flag argument.
+        """
         self.path = path
-        self.functions = function_call_list
+        self.visitor = visitor
+        self.operate_on_group = group_flag
+        self.functions = function_calls
         self.original_file_text = self.path.read_text()
         self.file_lines = self.original_file_text.split('\n')
         self.found_functions = self.find_functions_in_original_text()
+        self.found_function_groups = self.get_function_call_groups()
         self.function_distribution = self.get_binary_function_distribution()
         self.advanced_function_distribution = self.get_advanced_function_distribution()
 
@@ -117,15 +127,32 @@ class SourceFile:
                 line_values[line_num] = max(line_values[line_num], fe.call_type)
         return line_values
 
-    def get_new_file_text(self) -> str:
+    def get_new_file_text_function_based(self, func_visitor) -> str:
         """
         Modifies the original file text, replacing every function call with the modified version.
 
         :return: Returns the modified source code as a Python string.
         """
         new_text = self.original_file_text
-        for fe in reversed(self.found_functions):
-            new_text = new_text[:fe.char_start_in_file] + fe.as_new_version() + new_text[fe.char_end_in_file + 1:]
+        for fc in reversed(self.found_functions):
+            new_text = new_text[:fc.char_start_in_file] + func_visitor(fc) + new_text[fc.char_end_in_file + 1:]
+        return new_text
+
+    def get_new_file_text_group_based(self, group_visitor) -> str:
+        """
+        Modifies the original file text, replacing every function call group with the modified version.
+
+        :return: Returns the modified source code as a Python string.
+        """
+        # TODO: Add a unit test that works on function call groups
+        # TODO: Just create dummy RefactorBase-d test action classes that we use in all the unit tests
+        new_text = self.original_file_text
+        for fg in reversed(self.found_function_groups):
+            first_in_group = fg.function_calls[0]
+            last_in_group = fg.function_calls[-1]
+            new_text = new_text[:first_in_group.char_start_in_file] + group_visitor(fg) + new_text[last_in_group.char_end_in_file + 1:]
+            if '!msg.empty()' in new_text:
+                i = 1
         return new_text
 
     def write_new_text_to_file(self) -> None:
@@ -135,7 +162,10 @@ class SourceFile:
 
         :return: None
         """
-        self.path.write_text(self.get_new_file_text())
+        if self.operate_on_group:
+            self.path.write_text(self.get_new_file_text_group_based(self.visitor))
+        else:
+            self.path.write_text(self.get_new_file_text_function_based(self.visitor))
 
     def get_function_call_groups(self) -> list[FunctionCallGroup]:
         """
@@ -149,15 +179,14 @@ class SourceFile:
         group = FunctionCallGroup()
         last_call_index = len(self.found_functions) - 1
         for i, f in enumerate(self.found_functions):
-            this_single_call = f.summary()
             if f.starting_line_number == last_call_ended_on_line_number + 1:
-                group.add_function_call(this_single_call)
+                group.add_function_call(f)
                 if i == last_call_index:
                     all_args_for_file.append(group)
             else:
                 if group.started:
                     all_args_for_file.append(group)
-                group = FunctionCallGroup(this_single_call)  # reset the list starting with the current one
+                group = FunctionCallGroup(f)  # reset the list starting with the current one
                 if i == last_call_index:  # this is the last error, add it to the list before leaving
                     all_args_for_file.append(group)
             last_call_ended_on_line_number = f.ending_line_number

--- a/energyplus_refactor_helper/source_file.py
+++ b/energyplus_refactor_helper/source_file.py
@@ -148,11 +148,9 @@ class SourceFile:
         # TODO: Just create dummy RefactorBase-d test action classes that we use in all the unit tests
         new_text = self.original_file_text
         for fg in reversed(self.found_function_groups):
-            first_in_group = fg.function_calls[0]
-            last_in_group = fg.function_calls[-1]
-            new_text = new_text[:first_in_group.char_start_in_file] + group_visitor(fg) + new_text[last_in_group.char_end_in_file + 1:]
-            if '!msg.empty()' in new_text:
-                i = 1
+            first = fg.function_calls[0]
+            last = fg.function_calls[-1]
+            new_text = new_text[:first.char_start_in_file] + group_visitor(fg) + new_text[last.char_end_in_file + 1:]
         return new_text
 
     def write_new_text_to_file(self) -> None:

--- a/energyplus_refactor_helper/source_file.py
+++ b/energyplus_refactor_helper/source_file.py
@@ -7,21 +7,15 @@ from energyplus_refactor_helper.function_call import FunctionCall
 
 class SourceFile:
 
-    def __init__(self, path: Path, function_calls: list[str], group_flag: bool, visitor):
+    def __init__(self, path: Path, function_calls: list[str]):
         """
         This class represents a single source code file, processing it to find all matching function calls, and
         providing functionality to refactor them into a new form automatically.
 
         :param path: The Path instance pointing to this source file
         :param function_calls: The list of function calls currently being searched
-        :param group_flag: A flag indicating whether the action will operate on groups of function calls (if True)
-                                 or individual function calls (if False)
-        :param visitor: A callable function that takes either a FunctionCall or a FunctionCallInstance and returns a
-                        string.  The type should depend on the group_flag argument.
         """
         self.path = path
-        self.visitor = visitor
-        self.operate_on_group = group_flag
         self.functions = function_calls
         self.original_file_text = self.path.read_text()
         self.file_lines = self.original_file_text.split('\n')
@@ -153,17 +147,21 @@ class SourceFile:
             new_text = new_text[:first.char_start_in_file] + group_visitor(fg) + new_text[last.char_end_in_file + 1:]
         return new_text
 
-    def write_new_text_to_file(self) -> None:
+    def write_new_text_to_file(self, visitor, operate_on_group: bool) -> None:
         """
         Overwrites existing file contents with the modified version, replacing each function call with the new version
         as defined by the action instance itself.
 
+        :param visitor: A callable function that takes either a FunctionCall or a FunctionCallInstance and returns a
+                        string.  The type should depend on the group_flag argument.
+        :param operate_on_group: A flag indicating whether the action will operate on groups of function calls (if True)
+                                 or individual function calls (if False)
         :return: None
         """
-        if self.operate_on_group:
-            self.path.write_text(self.get_new_file_text_group_based(self.visitor))
+        if operate_on_group:
+            self.path.write_text(self.get_new_file_text_group_based(visitor))
         else:
-            self.path.write_text(self.get_new_file_text_function_based(self.visitor))
+            self.path.write_text(self.get_new_file_text_function_based(visitor))
 
     def get_function_call_groups(self) -> list[FunctionCallGroup]:
         """

--- a/energyplus_refactor_helper/source_folder.py
+++ b/energyplus_refactor_helper/source_folder.py
@@ -102,7 +102,7 @@ class SourceFolder:
         self.generate_json_outputs(output_dir / 'results.json')
         self.generate_file_summary_csv(output_dir / 'file_summary.csv')
         self.generate_line_details_csv(output_dir / 'lines_summary.csv')
-        # self.generate_line_details_plot(output_dir / 'distribution_plot.png')
+        self.generate_line_details_plot(output_dir / 'distribution_plot.png')
 
     def generate_json_outputs(self, output_json_file: Path) -> None:
         """

--- a/energyplus_refactor_helper/source_folder.py
+++ b/energyplus_refactor_helper/source_folder.py
@@ -2,143 +2,146 @@ from itertools import zip_longest
 from json import dumps
 import matplotlib.pyplot as plt
 from pathlib import Path
+from typing import Optional
 
 from energyplus_refactor_helper.logger import logger
 from energyplus_refactor_helper.source_file import SourceFile
 
 
 class SourceFolder:
-    def __init__(self, root: Path, out: Path, ignore: list[str], functions: list[str], edit: bool, call_group: bool,
-                 visitor, match=None):
+    def __init__(self, root: Path, functions: list[str]):
         """
         The SourceFolder class represents a folder that is to be analyzed during this refactor.  The SourceFolder is
         aware of all settings and will recursively search for matching functions and analyze/edit as needed.
 
         :param root: The root directory to search for this pass.
-        :param out: The output directory to write logs and analysis files.
-        :param ignore: A list of file names to ignore when looking for source files to analyze.
         :param functions: A list of function calls to search for in the source files.
-        :param edit: A flag for whether to actually edit the found source files in place or not.
-        :param call_group: A flag for whether the SourceFile instances will manipulate function calls or function call
-                           groups.  This is generally set by the action's visits_each_group() function.
-        :param visitor: A callable function that takes either a FunctionCall or a FunctionCallInstance and returns a
-                        string.  The type should depend on the group_flag argument.
-        :param match: A list of source file name patterns to match when searching.  If nothing is passed in, it will
-                      default to finding all .cc and .cpp files.
         """
         self.success = True  # assume success
         self.root = root
         self.function_call_list = functions
-        self.file_names_to_ignore = ignore
-        self.group_flag = call_group
-        self.visitor = visitor
-        self.matched_files = self.locate_source_files(match if match else ["*.cc", "*.cpp"])  # could include *.hh
-        logger.log(f"SourceFolder object constructed, identified {len(self.matched_files)} files ready to analyze.")
-        self._analyze()
-        self.generate_outputs(out)
-        if edit:
-            self.fixup_files_in_place()
         # make sure to update self.success if something goes wrong
 
-    def locate_source_files(self, match_patterns: list[str]) -> list[Path]:
+    def find_files(self, ignore: Optional[list[str]] = None, match_patterns: Optional[list[str]] = None) -> list[Path]:
         """
         A small worker function to locate source files inside the source directory.
 
+        :param ignore: A list of file names to ignore when looking for source files to analyze.
         :param match_patterns: A list of match patterns for filenames, which will match using glob functionality.
         :return: A list of absolute paths to source files found during the search.
         """
+        if ignore is None:
+            ignore = []
+        if match_patterns is None:
+            match_patterns = ["*.cc", "*.cpp"]  # could include *.hh
         all_files = []
         for pattern in match_patterns:
             files_matching = self.root.glob(f"**/{pattern}")
             all_files.extend(list(files_matching))
         files_to_keep = []
         for file in all_files:
-            if file.name in self.file_names_to_ignore:
+            if file.name in ignore:
                 logger.log(f"Encountered ignored file: {file.name}; skipping")
                 continue
             files_to_keep.append(file)
         return files_to_keep
 
-    def _analyze(self) -> None:
+    def analyze_source_files(self, matched_files: list[Path]) -> list[SourceFile]:
         """
         An internal worker function that processes all located source files and creates a list of SourceFile instances
         to be held on the self.processed_files member variable.
 
-        :return: None
+        :param matched_files: A list of Path instances to all matched source files to be processed here
+        :return: Returns a list of SourceFile instances which have been parsed for function calls.
         """
         logger.log("Processing files to identify function calls in each")
-        self.processed_files = []
-        for file_num, source_file in enumerate(sorted(self.matched_files)):
-            self.processed_files.append(SourceFile(source_file, self.function_call_list, self.group_flag, self.visitor))
-            logger.terminal_progress_bar(file_num + 1, len(self.matched_files), source_file.name)
+        processed_files = []
+        for file_num, source_file in enumerate(sorted(matched_files)):
+            processed_files.append(SourceFile(source_file, self.function_call_list))
+            logger.terminal_progress_bar(file_num + 1, len(matched_files), source_file.name)
         logger.terminal_progress_done()
+        return processed_files
 
-    def fixup_files_in_place(self) -> None:
+    @staticmethod
+    def rewrite_files_in_place(processed_files: list[SourceFile], visitor, operate_on_group: bool) -> None:
         """
         This function will loop over all processed files and fixup the function calls in place, overwriting the contents
         of the file.  Make sure the repository to be modified is prepared for this...git commit, etc.
 
+        :param processed_files: A list of SourceFile instances that has been built by calling analyze_source_files
+        :param visitor: A callable function that takes either a FunctionCall or a FunctionCallInstance and returns a
+                        string.  The type should depend on the group_flag argument.
+        :param operate_on_group: A flag indicating whether the action will operate on groups of function calls (if True)
+                                 or individual function calls (if False)
         :return: None
         """
         logger.log("Now fixing up files in place with new function calls")
-        num_files = len(self.processed_files)
-        for file_num, s in enumerate(self.processed_files):
-            s.write_new_text_to_file()  # rewrite the file contents
+        num_files = len(processed_files)
+        for file_num, s in enumerate(processed_files):
+            s.write_new_text_to_file(visitor, operate_on_group)  # rewrite the file contents
             logger.terminal_progress_bar(file_num + 1, num_files, s.path.name)
         logger.terminal_progress_done()
 
-    def generate_outputs(self, output_dir: Path) -> None:
+    def generate_reports(self, processed_files: list[SourceFile], output_dir: Path, skip_plots: bool) -> None:
         """
         This function will generate all output files for this analysis, and drop them all into the specified output
         directory.  The output files will grow over time, and may be dependent on input arguments later.  For now the
         list includes a JSON summary, a file summary CSV, a line-by-line summary CSV, and a
         difficult-to-read-but-maybe-interesting plot showing the function distribution in each file.
 
+        :param processed_files: A list of SourceFile instances that has been built by calling analyze_source_files
         :param output_dir: The output directory to write the outputs.  It will be created if it doesn't exist.
+        :param skip_plots: A flag for whether we are skipping plot generation, which can be time-consuming
         :return: None
         """
         if not output_dir.exists():
             output_dir.mkdir()
-        self.generate_json_outputs(output_dir / 'results.json')
-        self.generate_file_summary_csv(output_dir / 'file_summary.csv')
-        self.generate_line_details_csv(output_dir / 'lines_summary.csv')
-        self.generate_line_details_plot(output_dir / 'distribution_plot.png')
+        self.generate_json_outputs(processed_files, output_dir / 'results.json')
+        self.generate_file_summary_csv(processed_files, output_dir / 'file_summary.csv')
+        self.generate_line_details_csv(processed_files, output_dir / 'lines_summary.csv')
+        if not skip_plots:
+            self.generate_line_details_plot(processed_files, output_dir / 'distribution_plot.png')
 
-    def generate_json_outputs(self, output_json_file: Path) -> None:
+    @staticmethod
+    def generate_json_outputs(processed_files: list[SourceFile], output_json_file: Path) -> None:
         """
         This function generates an output JSON summary.  The summary includes each function call, along with the full
         list of parsed arguments, and the starting and ending line of each.  It also includes a special summary of each
         "group" of function calls, where a group is defined as function calls that exist on adjacent lines of code.
         This is primarily useful for refactoring "groups" of function calls together in a meaningful way.
 
+        :param processed_files: A list of SourceFile instances that has been built by calling analyze_source_files
         :param output_json_file: The output file path to write.
         :return: None
         """
         logger.log("Building JSON summary output")
         full_json_content = {}
-        for file_num, source_file in enumerate(self.processed_files):
+        for file_num, source_file in enumerate(processed_files):
             full_json_content[source_file.path.name] = [g.to_json() for g in source_file.get_function_call_groups()]
-            logger.terminal_progress_bar(file_num + 1, len(self.processed_files), source_file.path.name)
+            logger.terminal_progress_bar(file_num + 1, len(processed_files), source_file.path.name)
         logger.terminal_progress_done()
         output_json_file.write_text(dumps(full_json_content, indent=2))
 
-    def generate_file_summary_csv(self, output_csv_file: Path) -> None:
+    @staticmethod
+    def generate_file_summary_csv(processed_files: list[SourceFile], output_csv_file: Path) -> None:
         """
         This function generates a file-by-file summary of how many function calls were parsed in each file.  Each row
         is a different file, with the number of successful function call parses and the number of failed parses.  This
         file is primarily a debugging aid, but could be useful for understanding how many function calls are in each.
 
+        :param processed_files: A list of SourceFile instances that has been built by calling analyze_source_files
         :param output_csv_file: The output file path to write.
         :return: None
         """
         s = "File,Good,Bad\n"
-        for result in self.processed_files:
+        for result in processed_files:
             good = sum([1 if fe.appears_successful else 0 for fe in result.found_functions])
             bad = sum([0 if fe.appears_successful else 1 for fe in result.found_functions])
             s += f"{result.path},{good},{bad}\n"
         output_csv_file.write_text(s)
 
-    def generate_line_details_csv(self, output_csv_file: Path) -> None:
+    @staticmethod
+    def generate_line_details_csv(processed_files: list[SourceFile], output_csv_file: Path) -> None:
         """
         This function generates a basic distribution of function calls found in each file.  The file is a CSV where
         each file is a different column.  The rows are lines of code in that file, and the value in the dataset is
@@ -146,15 +149,16 @@ class SourceFolder:
         plotted to show how the function calls are distributed in that file.  This data could potentially be fed to
         other algorithms to help analyze/visualize/whatever this distribution.
 
+        :param processed_files: A list of SourceFile instances that has been built by calling analyze_source_files
         :param output_csv_file: The output file path to write.
         :return: None
         """
-        all_lists = [[x.path.name, *x.function_distribution] for x in self.processed_files]
+        all_lists = [[x.path.name, *x.function_distribution] for x in processed_files]
         zipped_lists = zip_longest(*all_lists, fillvalue='')
         csv_string = ''.join([",".join(map(str, row)) + "\n" for row in zipped_lists])
         output_csv_file.write_text(csv_string)
 
-    def generate_line_details_plot(self, output_file_file: Path) -> None:
+    def generate_line_details_plot(self, processed_files: list[SourceFile], output_file_file: Path) -> None:
         """
         This function generates a (potentially huge) png plot of the matched function distribution in each file.  The
         generated png plots the function distribution based on the integer function types, so if this particular
@@ -162,13 +166,14 @@ class SourceFolder:
         will be very tall if you are analyzing lots of files.  It is possible this output will be enabled/disabled
         based on input flags later.
 
+        :param processed_files: A list of SourceFile instances that has been built by calling analyze_source_files
         :param output_file_file: The output file path to write.
         :return: None
         """
         logger.log("Building plot data")
         y_max = len(self.function_call_list)
-        file_names = [x.path.name for x in self.processed_files]
-        data = [x.advanced_function_distribution for x in self.processed_files]
+        file_names = [x.path.name for x in processed_files]
+        data = [x.advanced_function_distribution for x in processed_files]
         num_data_sets = len(data)
         fig, axes = plt.subplots(num_data_sets, 1, layout='constrained')
         fig.set_size_inches(8, int(num_data_sets / 2))

--- a/energyplus_refactor_helper/test/test_action.py
+++ b/energyplus_refactor_helper/test/test_action.py
@@ -14,6 +14,6 @@ class TestActionBase:
         assert isinstance(rb.analysis_root_from_repo_root(Path('dummy')), Path)
         assert isinstance(rb.visits_each_group(), bool)
         fc = FunctionCall(0, 'f(x, y);', 0, 0, 0, 'x')
-        assert isinstance(rb.function_visitor(fc), str)
+        assert isinstance(rb.visitor(fc), str)
         with raises(NotImplementedError):
             rb.function_calls()

--- a/energyplus_refactor_helper/test/test_action.py
+++ b/energyplus_refactor_helper/test/test_action.py
@@ -2,18 +2,68 @@ from pathlib import Path
 
 from pytest import raises
 
-from energyplus_refactor_helper.action import RefactorBase
+from energyplus_refactor_helper.action import RefactorBase, ErrorCallRefactor
 from energyplus_refactor_helper.function_call import FunctionCall
+from energyplus_refactor_helper.function_call_group import FunctionCallGroup
 
 
-class TestActionBase:
+def test_default_interface():
+    rb = RefactorBase()
+    with raises(NotImplementedError):
+        rb.run(Path(), Path(), True, True)
+    fc = FunctionCall(0, 'f', 0, 0, 0, 'f(x, y)')
+    assert isinstance(rb.base_function_call_visitor(fc), str)
 
-    def test_interface(self):
-        rb = RefactorBase()
-        assert isinstance(rb.file_names_to_ignore(), list)
-        assert isinstance(rb.analysis_root_from_repo_root(Path('dummy')), Path)
-        assert isinstance(rb.visits_each_group(), bool)
-        fc = FunctionCall(0, 'f(x, y);', 0, 0, 0, 'x')
-        assert isinstance(rb.visitor(fc), str)
-        with raises(NotImplementedError):
-            rb.function_calls()
+
+def test_error_call_visitor():
+    ecr = ErrorCallRefactor()
+    s = ecr.CallSymbols
+    # Severe, continue, continue, fatal
+    fcs = [
+        FunctionCall(s.ShowSevereError, 'ShowSevereError', 1, 0, 0, 'ShowSevereError(s, "Black");'),
+        FunctionCall(s.ShowContinueError, 'ShowContinueError', 1, 0, 0, 'ShowContinueError(s, "then");'),
+        FunctionCall(s.ShowContinueError, 'ShowContinueError', 1, 0, 0, 'ShowContinueError(s, "white are");'),
+        FunctionCall(s.ShowFatalError, 'ShowFatalError', 1, 0, 0, 'ShowFatalError(s, "all I see");'),
+    ]
+    group = FunctionCallGroup()
+    [group.add_function_call(f) for f in fcs]
+    expected_text = 'emitErrorMessages(s, -999, {"Black", "then", "white are", "all I see"}, true);'
+    resulting_text = ecr.visitor(group)
+    assert expected_text == resulting_text
+    # Test with preceding text
+    fcs = [
+        FunctionCall(s.ShowSevereError, 'ShowSevereError', 1, 0, 0, 'ShowSevereError(s, "Foo");'),
+        FunctionCall(s.ShowFatalError, 'ShowFatalError', 1, 0, 3, 'Hi; ShowFatalError(s, "bar");'),
+    ]
+    group = FunctionCallGroup()
+    [group.add_function_call(f) for f in fcs]
+    expected_text = 'ShowSevereError(s, "Foo");\nHi;ShowFatalError(s, "bar");'
+    resulting_text = ecr.visitor(group)
+    assert expected_text == resulting_text
+    # now just a standalone warning
+    fcs = [
+        FunctionCall(s.ShowWarningError, 'ShowWarningError', 1, 0, 0, 'ShowWarningError(s, "Foo");'),
+    ]
+    group = FunctionCallGroup()
+    [group.add_function_call(f) for f in fcs]
+    expected_text = 'emitWarningMessage(s, -999, "Foo");'
+    resulting_text = ecr.visitor(group)
+    assert expected_text == resulting_text
+    # now just a standalone severe
+    fcs = [
+        FunctionCall(s.ShowSevereError, 'ShowSevereError', 1, 0, 0, 'ShowSevereError(s, "Foo");'),
+    ]
+    group = FunctionCallGroup()
+    [group.add_function_call(f) for f in fcs]
+    expected_text = 'emitErrorMessage(s, -999, "Foo", false);'
+    resulting_text = ecr.visitor(group)
+    assert expected_text == resulting_text
+    # now just a single standalone fatal
+    fcs = [
+        FunctionCall(s.ShowFatalError, 'ShowFatalError', 1, 0, 0, 'ShowFatalError(s, "Foo");'),
+    ]
+    group = FunctionCallGroup()
+    [group.add_function_call(f) for f in fcs]
+    expected_text = 'emitErrorMessage(s, -999, "Foo", true);'
+    resulting_text = ecr.visitor(group)
+    assert expected_text == resulting_text

--- a/energyplus_refactor_helper/test/test_action.py
+++ b/energyplus_refactor_helper/test/test_action.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from pytest import raises
 
 from energyplus_refactor_helper.action import RefactorBase
+from energyplus_refactor_helper.function_call import FunctionCall
 
 
 class TestActionBase:
@@ -11,5 +12,8 @@ class TestActionBase:
         rb = RefactorBase()
         assert isinstance(rb.file_names_to_ignore(), list)
         assert isinstance(rb.analysis_root_from_repo_root(Path('dummy')), Path)
+        assert isinstance(rb.visits_each_group(), bool)
+        fc = FunctionCall(0, 'f(x, y);', 0, 0, 0, 'x')
+        assert isinstance(rb.function_visitor(fc), str)
         with raises(NotImplementedError):
             rb.function_calls()

--- a/energyplus_refactor_helper/test/test_source_file.py
+++ b/energyplus_refactor_helper/test/test_source_file.py
@@ -7,12 +7,14 @@ from energyplus_refactor_helper.source_file import SourceFile
 this_file = Path(__file__).resolve()
 test_file = this_file.parent / 'fake_source_folder' / 'src' / 'EnergyPlus' / 'test_file.cc'
 funcs = ErrorCallRefactor().function_calls()  # TODO: use a custom list not a demo action
+group_flag = ErrorCallRefactor().visits_each_group()
+function_visitor = ErrorCallRefactor().function_visitor
 
 
 class TestSourceFile:
 
     def test_basic_operation(self):
-        sf = SourceFile(test_file, funcs)
+        sf = SourceFile(test_file, funcs, group_flag, function_visitor)
         sf.find_functions_in_original_text()
         assert len(sf.found_functions) == 9
 
@@ -42,7 +44,7 @@ namespace UnitarySystems {
 }
 """
         p.write_text(raw_text)
-        sf = SourceFile(p, funcs)
+        sf = SourceFile(p, funcs, group_flag, function_visitor)
         sf.find_functions_in_original_text()
         assert len(sf.found_functions) == 2
         found_error = sf.found_functions[0]
@@ -66,7 +68,7 @@ void func() {
 }
 """
         p.write_text(raw_text)
-        sf = SourceFile(p, funcs)
+        sf = SourceFile(p, funcs, group_flag, function_visitor)
         sf.find_functions_in_original_text()
         assert len(sf.found_functions) == 3
         error_call_info = sf.get_function_call_groups()
@@ -79,7 +81,7 @@ void func() {
           if (j > NumCur) ShowFatalError(state, "Out of range, too high (FAN) in ADS simulation");
         """
         p.write_text(raw_text)
-        sf = SourceFile(p, funcs)
+        sf = SourceFile(p, funcs, group_flag, function_visitor)
         sf.find_functions_in_original_text()
         assert len(sf.found_functions) == 1
         found_error = sf.found_functions[0]
@@ -110,7 +112,7 @@ void func() {
     );
         """
         p.write_text(raw_text)
-        sf = SourceFile(p, funcs)
+        sf = SourceFile(p, funcs, group_flag, function_visitor)
         sf.find_functions_in_original_text()
         found_error = sf.found_functions[0]
         assert not found_error.appears_successful

--- a/energyplus_refactor_helper/test/test_source_file.py
+++ b/energyplus_refactor_helper/test/test_source_file.py
@@ -1,16 +1,13 @@
 from pathlib import Path
 from tempfile import mkstemp
 
-from energyplus_refactor_helper.action import ErrorCallRefactor
 from energyplus_refactor_helper.function_call import FunctionCall
 from energyplus_refactor_helper.function_call_group import FunctionCallGroup
 from energyplus_refactor_helper.source_file import SourceFile
 
 this_file = Path(__file__).resolve()
 test_file = this_file.parent / 'fake_source_folder' / 'src' / 'EnergyPlus' / 'test_file.cc'
-funcs = ErrorCallRefactor().function_calls()  # TODO: use a custom list not a demo action
-group_flag = ErrorCallRefactor().visits_each_group()
-function_visitor = ErrorCallRefactor().visitor
+funcs = ['ShowSevereError', 'ShowContinueError', 'ShowFatalError', 'ShowWarningError']
 
 
 def test_basic_operation():
@@ -124,7 +121,7 @@ ShowContinueError(state,
 def test_call_type_worker_function():
     message = "Something - ShowContinueError(blah,"
     call, ind = SourceFile.find_function_in_raw_line(funcs, message)
-    assert call == 3
+    assert call == funcs.index('ShowContinueError')
     assert ind == 12
 
     message = "Nothing here!"

--- a/energyplus_refactor_helper/test/test_source_file.py
+++ b/energyplus_refactor_helper/test/test_source_file.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from tempfile import mkstemp
 
 from energyplus_refactor_helper.action import ErrorCallRefactor
+from energyplus_refactor_helper.function_call import FunctionCall
+from energyplus_refactor_helper.function_call_group import FunctionCallGroup
 from energyplus_refactor_helper.source_file import SourceFile
 
 this_file = Path(__file__).resolve()
@@ -11,119 +13,152 @@ group_flag = ErrorCallRefactor().visits_each_group()
 function_visitor = ErrorCallRefactor().function_visitor
 
 
-class TestSourceFile:
+def test_basic_operation():
+    sf = SourceFile(test_file, funcs, group_flag, function_visitor)
+    sf.find_functions_in_original_text()
+    assert len(sf.found_functions) == 9
 
-    def test_basic_operation(self):
-        sf = SourceFile(test_file, funcs, group_flag, function_visitor)
-        sf.find_functions_in_original_text()
-        assert len(sf.found_functions) == 9
 
-    def test_complex_ish_file(self):
-        _, file_path = mkstemp()
-        p = Path(file_path)
-        raw_text = """// INCLUDES
+def test_complex_ish_file():
+    _, file_path = mkstemp()
+    p = Path(file_path)
+    raw_text = """// INCLUDES
 #include <string>
 
 namespace UnitarySystems {
-    Object *Object::factory(std::string objectName)
-    {
-        ShowSevereError(state, format("Factory Error: {}", objectName));
-        return nullptr;
-    }
-
-    void func()
-    {
-        ShowContinueError(state,
-            format(
-                "It might be this: {} or that: {}",
-                state.data->Node(1).Temp,
-                state.data->CoolVector[x].attributeY
-            )
-        );
-    }
+Object *Object::factory(std::string objectName)
+{
+    ShowSevereError(state, format("Factory Error: {}", objectName));
+    return nullptr;
 }
-"""
-        p.write_text(raw_text)
-        sf = SourceFile(p, funcs, group_flag, function_visitor)
-        sf.find_functions_in_original_text()
-        assert len(sf.found_functions) == 2
-        found_error = sf.found_functions[0]
-        assert found_error.appears_successful
-        assert found_error.char_start_in_file == 124
-        assert found_error.char_end_in_file == 187
-        found_error_2 = sf.found_functions[1]
-        assert found_error_2.appears_successful
-        assert found_error_2.char_start_in_file == 250
-        assert found_error_2.char_end_in_file == 465
 
-    def test_last_error_group_has_multiple_errors(self):
-        _, file_path = mkstemp()
-        p = Path(file_path)
-        raw_text = """
-void func() {
-    ShowSevereError(state, format("Factory Error: {}", objectName));
-    int i = 1;
-    ShowSevereError(state, format("Factory Error: {}", objectName));
-    ShowSevereError(state, format("Factory Error: {}", objectName));
-}
-"""
-        p.write_text(raw_text)
-        sf = SourceFile(p, funcs, group_flag, function_visitor)
-        sf.find_functions_in_original_text()
-        assert len(sf.found_functions) == 3
-        error_call_info = sf.get_function_call_groups()
-        assert len(error_call_info) == 2
-
-    def test_error_after_text(self):
-        _, file_path = mkstemp()
-        p = Path(file_path)
-        raw_text = """
-          if (j > NumCur) ShowFatalError(state, "Out of range, too high (FAN) in ADS simulation");
-        """
-        p.write_text(raw_text)
-        sf = SourceFile(p, funcs, group_flag, function_visitor)
-        sf.find_functions_in_original_text()
-        assert len(sf.found_functions) == 1
-        found_error = sf.found_functions[0]
-        assert found_error.appears_successful
-        assert found_error.char_start_in_file == 27
-        assert found_error.char_end_in_file == 98
-
-    def test_skips_long_parse(self):
-        _, file_path = mkstemp()
-        p = Path(file_path)
-        raw_text = """
+void func()
+{
     ShowContinueError(state,
         format(
             "It might be this: {} or that: {}",
             state.data->Node(1).Temp,
-            state.data->CoolVector[x].attributeY,
-            OK,
-            SO,
-            WELL,
-            THIS,
-            THIS,
-            THIS,
-            THIS,
-            THIS,
-            IS,
-            LONG
+            state.data->CoolVector[x].attributeY
         )
     );
-        """
-        p.write_text(raw_text)
-        sf = SourceFile(p, funcs, group_flag, function_visitor)
-        sf.find_functions_in_original_text()
-        found_error = sf.found_functions[0]
-        assert not found_error.appears_successful
+}
+}
+"""
+    p.write_text(raw_text)
+    sf = SourceFile(p, funcs, group_flag, function_visitor)
+    sf.find_functions_in_original_text()
+    assert len(sf.found_functions) == 2
+    found_error = sf.found_functions[0]
+    assert found_error.appears_successful
+    assert found_error.char_start_in_file == 112
+    assert found_error.char_end_in_file == 175
+    found_error_2 = sf.found_functions[1]
+    assert found_error_2.appears_successful
+    assert found_error_2.char_start_in_file == 218
+    assert found_error_2.char_end_in_file == 409
 
-    def test_call_type_worker_function(self):
-        message = "Something - ShowContinueError(blah,"
-        call, ind = SourceFile.find_function_in_raw_line(funcs, message)
-        assert call == 3
-        assert ind == 12
 
-        message = "Nothing here!"
-        call, ind = SourceFile.find_function_in_raw_line(funcs, message)
-        assert call is None
-        assert ind == -1
+def test_last_error_group_has_multiple_errors():
+    _, file_path = mkstemp()
+    p = Path(file_path)
+    raw_text = """
+void func() {
+ShowSevereError(state, format("Factory Error: {}", objectName));
+int i = 1;
+ShowSevereError(state, format("Factory Error: {}", objectName));
+ShowSevereError(state, format("Factory Error: {}", objectName));
+}
+"""
+    p.write_text(raw_text)
+    sf = SourceFile(p, funcs, group_flag, function_visitor)
+    sf.find_functions_in_original_text()
+    assert len(sf.found_functions) == 3
+    error_call_info = sf.get_function_call_groups()
+    assert len(error_call_info) == 2
+
+
+def test_error_after_text():
+    _, file_path = mkstemp()
+    p = Path(file_path)
+    raw_text = """
+      if (j > NumCur) ShowFatalError(state, "Out of range, too high (FAN) in ADS simulation");
+    """
+    p.write_text(raw_text)
+    sf = SourceFile(p, funcs, group_flag, function_visitor)
+    sf.find_functions_in_original_text()
+    assert len(sf.found_functions) == 1
+    found_error = sf.found_functions[0]
+    assert found_error.appears_successful
+    assert found_error.char_start_in_file == 23
+    assert found_error.char_end_in_file == 94
+
+
+def test_skips_long_parse():
+    _, file_path = mkstemp()
+    p = Path(file_path)
+    raw_text = """
+ShowContinueError(state,
+    format(
+        "It might be this: {} or that: {}",
+        state.data->Node(1).Temp,
+        state.data->CoolVector[x].attributeY,
+        OK,
+        SO,
+        WELL,
+        THIS,
+        THIS,
+        THIS,
+        THIS,
+        THIS,
+        IS,
+        LONG
+    )
+);
+    """
+    p.write_text(raw_text)
+    sf = SourceFile(p, funcs, group_flag, function_visitor)
+    found_error = sf.found_functions[0]
+    assert not found_error.appears_successful
+
+
+def test_call_type_worker_function():
+    message = "Something - ShowContinueError(blah,"
+    call, ind = SourceFile.find_function_in_raw_line(funcs, message)
+    assert call == 3
+    assert ind == 12
+
+    message = "Nothing here!"
+    call, ind = SourceFile.find_function_in_raw_line(funcs, message)
+    assert call is None
+    assert ind == -1
+
+
+def f_visitor(f: FunctionCall) -> str:  # basically reproduce default action
+    args = ', '.join(f.parse_arguments())
+    return f"{f.function_name}({args});"
+
+
+def f_group_visitor(f: FunctionCallGroup) -> str:  # do a dumb example
+    starting_char = f.function_calls[0].parse_arguments()[0][0]  # first character of first arg
+    last_char = f.function_calls[-1].parse_arguments()[-1][-1]  # last character of last arg
+    return f"{starting_char}{last_char}"
+
+
+def test_new_file_text_function_based():
+    _, file_path = mkstemp()
+    p = Path(file_path)
+    raw_text = "ShowContinueError(s, \nx);"
+    p.write_text(raw_text)
+    sf = SourceFile(p, funcs, False, f_visitor)
+    sf.write_new_text_to_file()
+    assert "ShowContinueError(s, x);" in p.read_text()
+
+
+def test_new_file_text_group_based():
+    _, file_path = mkstemp()
+    p = Path(file_path)
+    raw_text = "ShowContinueError(s, \nx);"
+    p.write_text(raw_text)
+    sf = SourceFile(p, funcs, True, f_group_visitor)
+    sf.write_new_text_to_file()
+    assert "sx" in p.read_text()

--- a/energyplus_refactor_helper/test/test_source_file.py
+++ b/energyplus_refactor_helper/test/test_source_file.py
@@ -10,11 +10,11 @@ this_file = Path(__file__).resolve()
 test_file = this_file.parent / 'fake_source_folder' / 'src' / 'EnergyPlus' / 'test_file.cc'
 funcs = ErrorCallRefactor().function_calls()  # TODO: use a custom list not a demo action
 group_flag = ErrorCallRefactor().visits_each_group()
-function_visitor = ErrorCallRefactor().function_visitor
+function_visitor = ErrorCallRefactor().visitor
 
 
 def test_basic_operation():
-    sf = SourceFile(test_file, funcs, group_flag, function_visitor)
+    sf = SourceFile(test_file, funcs)
     sf.find_functions_in_original_text()
     assert len(sf.found_functions) == 9
 
@@ -45,7 +45,7 @@ void func()
 }
 """
     p.write_text(raw_text)
-    sf = SourceFile(p, funcs, group_flag, function_visitor)
+    sf = SourceFile(p, funcs)
     sf.find_functions_in_original_text()
     assert len(sf.found_functions) == 2
     found_error = sf.found_functions[0]
@@ -70,7 +70,7 @@ ShowSevereError(state, format("Factory Error: {}", objectName));
 }
 """
     p.write_text(raw_text)
-    sf = SourceFile(p, funcs, group_flag, function_visitor)
+    sf = SourceFile(p, funcs)
     sf.find_functions_in_original_text()
     assert len(sf.found_functions) == 3
     error_call_info = sf.get_function_call_groups()
@@ -84,7 +84,7 @@ def test_error_after_text():
       if (j > NumCur) ShowFatalError(state, "Out of range, too high (FAN) in ADS simulation");
     """
     p.write_text(raw_text)
-    sf = SourceFile(p, funcs, group_flag, function_visitor)
+    sf = SourceFile(p, funcs)
     sf.find_functions_in_original_text()
     assert len(sf.found_functions) == 1
     found_error = sf.found_functions[0]
@@ -116,7 +116,7 @@ ShowContinueError(state,
 );
     """
     p.write_text(raw_text)
-    sf = SourceFile(p, funcs, group_flag, function_visitor)
+    sf = SourceFile(p, funcs)
     found_error = sf.found_functions[0]
     assert not found_error.appears_successful
 
@@ -149,8 +149,8 @@ def test_new_file_text_function_based():
     p = Path(file_path)
     raw_text = "ShowContinueError(s, \nx);"
     p.write_text(raw_text)
-    sf = SourceFile(p, funcs, False, f_visitor)
-    sf.write_new_text_to_file()
+    sf = SourceFile(p, funcs)
+    sf.write_new_text_to_file(f_visitor, False)
     assert "ShowContinueError(s, x);" in p.read_text()
 
 
@@ -159,6 +159,6 @@ def test_new_file_text_group_based():
     p = Path(file_path)
     raw_text = "ShowContinueError(s, \nx);"
     p.write_text(raw_text)
-    sf = SourceFile(p, funcs, True, f_group_visitor)
-    sf.write_new_text_to_file()
+    sf = SourceFile(p, funcs)
+    sf.write_new_text_to_file(f_group_visitor, True)
     assert "sx" in p.read_text()

--- a/energyplus_refactor_helper/test/test_source_folder.py
+++ b/energyplus_refactor_helper/test/test_source_folder.py
@@ -3,10 +3,9 @@ import tempfile
 from pathlib import Path
 from tempfile import mkdtemp
 
-from energyplus_refactor_helper.action import ErrorCallRefactor
 from energyplus_refactor_helper.source_folder import SourceFolder
 
-funcs = ErrorCallRefactor().function_calls()  # TODO: Use a custom dummy list here, not a real demo
+funcs = ['ShowSevereError', 'ShowContinueError', 'ShowFatalError', 'ShowWarningError']
 
 
 class TestSourceFolder:

--- a/energyplus_refactor_helper/test/test_source_folder.py
+++ b/energyplus_refactor_helper/test/test_source_folder.py
@@ -7,6 +7,8 @@ from energyplus_refactor_helper.action import ErrorCallRefactor
 from energyplus_refactor_helper.source_folder import SourceFolder
 
 funcs = ErrorCallRefactor().function_calls()  # TODO: Use a custom dummy list here, not a real demo
+group_flag = ErrorCallRefactor().visits_each_group()
+function_visitor = ErrorCallRefactor().function_visitor
 
 
 class TestSourceFolder:
@@ -19,17 +21,25 @@ class TestSourceFolder:
 
     def test_it_finds_matching_files_recursively(self):
         fake_source_folder, dummy_output_folder = TestSourceFolder.set_up_dirs()
-        sf = SourceFolder(fake_source_folder, dummy_output_folder, [], funcs, False)
+        sf = SourceFolder(
+            fake_source_folder, dummy_output_folder, [], funcs, False, group_flag, function_visitor
+        )
         assert len(sf.matched_files) == 4
 
     def test_it_finds_matching_files_including_ignored(self):
         fake_source_folder, dummy_output_folder = TestSourceFolder.set_up_dirs()
-        sf = SourceFolder(fake_source_folder, dummy_output_folder, ['file_to_ignore.cc'], funcs, False)
+        sf = SourceFolder(
+            fake_source_folder, dummy_output_folder, ['file_to_ignore.cc'], funcs,
+            False, group_flag, function_visitor
+        )
         assert len(sf.matched_files) == 3
 
     def test_full_workflow(self):
         fake_source_folder, dummy_output_folder = TestSourceFolder.set_up_dirs()
-        sf = SourceFolder(fake_source_folder, dummy_output_folder, ['file_to_ignore.cc'], funcs, False)
+        sf = SourceFolder(
+            fake_source_folder, dummy_output_folder, ['file_to_ignore.cc'], funcs,
+            False, group_flag, function_visitor
+        )
         assert sf.success
         output_files_found = list(dummy_output_folder.glob('*'))
         assert len(output_files_found) > 0
@@ -37,7 +47,10 @@ class TestSourceFolder:
     def test_it_creates_output_folder_if_not_exists(self):
         src_folder, dummy_output_folder = TestSourceFolder.set_up_dirs()
         nonexistent_dummy_output_folder = dummy_output_folder / 'dummy'
-        sf = SourceFolder(src_folder, nonexistent_dummy_output_folder, ['file_to_ignore.cc'], funcs, False)
+        sf = SourceFolder(
+            src_folder, nonexistent_dummy_output_folder, ['file_to_ignore.cc'], funcs,
+            False, group_flag, function_visitor
+        )
         assert sf.success
         output_files_found = list(nonexistent_dummy_output_folder.glob('*'))
         assert len(output_files_found) > 0
@@ -46,7 +59,10 @@ class TestSourceFolder:
         new_scratch_dir = Path(tempfile.mkdtemp()) / 'new_scratch_dir'
         test_source_dir, dummy_output_folder = TestSourceFolder.set_up_dirs()
         copytree(test_source_dir, new_scratch_dir)
-        sf = SourceFolder(new_scratch_dir, dummy_output_folder, ['file_to_ignore.cc'], funcs, True)
+        sf = SourceFolder(
+            new_scratch_dir, dummy_output_folder, ['file_to_ignore.cc'], funcs,
+            True, group_flag, function_visitor
+        )
         assert sf.success
         output_files_found = list(dummy_output_folder.glob('*'))
         assert len(output_files_found) > 0

--- a/energyplus_refactor_helper/test/test_source_folder.py
+++ b/energyplus_refactor_helper/test/test_source_folder.py
@@ -7,8 +7,6 @@ from energyplus_refactor_helper.action import ErrorCallRefactor
 from energyplus_refactor_helper.source_folder import SourceFolder
 
 funcs = ErrorCallRefactor().function_calls()  # TODO: Use a custom dummy list here, not a real demo
-group_flag = ErrorCallRefactor().visits_each_group()
-function_visitor = ErrorCallRefactor().function_visitor
 
 
 class TestSourceFolder:
@@ -22,49 +20,51 @@ class TestSourceFolder:
     def test_it_finds_matching_files_recursively(self):
         fake_source_folder, dummy_output_folder = TestSourceFolder.set_up_dirs()
         sf = SourceFolder(
-            fake_source_folder, dummy_output_folder, [], funcs, False, group_flag, function_visitor
+            fake_source_folder, funcs
         )
-        assert len(sf.matched_files) == 4
+        assert len(sf.find_files()) == 4
 
     def test_it_finds_matching_files_including_ignored(self):
         fake_source_folder, dummy_output_folder = TestSourceFolder.set_up_dirs()
-        sf = SourceFolder(
-            fake_source_folder, dummy_output_folder, ['file_to_ignore.cc'], funcs,
-            False, group_flag, function_visitor
-        )
-        assert len(sf.matched_files) == 3
+        sf = SourceFolder(fake_source_folder, funcs)
+        assert len(sf.find_files(['file_to_ignore.cc'])) == 3
 
     def test_full_workflow(self):
         fake_source_folder, dummy_output_folder = TestSourceFolder.set_up_dirs()
-        sf = SourceFolder(
-            fake_source_folder, dummy_output_folder, ['file_to_ignore.cc'], funcs,
-            False, group_flag, function_visitor
-        )
+        sf = SourceFolder(fake_source_folder, funcs)
         assert sf.success
+        matched_source_files = sf.find_files(['file_to_ignore.cc'])
+        processed_source_files = sf.analyze_source_files(matched_source_files)
+        sf.generate_reports(processed_source_files, dummy_output_folder, skip_plots=True)
         output_files_found = list(dummy_output_folder.glob('*'))
         assert len(output_files_found) > 0
 
     def test_it_creates_output_folder_if_not_exists(self):
         src_folder, dummy_output_folder = TestSourceFolder.set_up_dirs()
         nonexistent_dummy_output_folder = dummy_output_folder / 'dummy'
-        sf = SourceFolder(
-            src_folder, nonexistent_dummy_output_folder, ['file_to_ignore.cc'], funcs,
-            False, group_flag, function_visitor
-        )
-        assert sf.success
+        sf = SourceFolder(src_folder, funcs)
+        matched_source_files = sf.find_files(['file_to_ignore.cc'])
+        processed_source_files = sf.analyze_source_files(matched_source_files)
+        sf.generate_reports(processed_source_files, nonexistent_dummy_output_folder, skip_plots=True)
         output_files_found = list(nonexistent_dummy_output_folder.glob('*'))
         assert len(output_files_found) > 0
 
+    @staticmethod
+    def function_visitor(f):
+        args = ', '.join(f.parse_arguments())
+        return f"ShowSevereError({args});"
+
     def test_edit_in_place_workflow(self):
         new_scratch_dir = Path(tempfile.mkdtemp()) / 'new_scratch_dir'
-        test_source_dir, dummy_output_folder = TestSourceFolder.set_up_dirs()
+        test_source_dir, _ = TestSourceFolder.set_up_dirs()
         copytree(test_source_dir, new_scratch_dir)
-        sf = SourceFolder(
-            new_scratch_dir, dummy_output_folder, ['file_to_ignore.cc'], funcs,
-            True, group_flag, function_visitor
-        )
+        sf = SourceFolder(new_scratch_dir, funcs)
+        matched_source_files = sf.find_files(['file_to_ignore.cc'])
+        processed_source_files = sf.analyze_source_files(matched_source_files)
+        sf.rewrite_files_in_place(processed_source_files, self.function_visitor, False)
         assert sf.success
-        output_files_found = list(dummy_output_folder.glob('*'))
+        print(f"trying to process files in {new_scratch_dir}")
+        output_files_found = list(new_scratch_dir.glob('*'))
         assert len(output_files_found) > 0
         file_to_check = new_scratch_dir / 'test_file.cc'
         assert file_to_check.exists()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ matplotlib
 pytest
 sphinx
 wheel
+
+spacy
+# then python -m spacy download en_core_web_sm and python -m spacy download en_core_web_md


### PR DESCRIPTION
Modified the code so it can write out function call groups.  As of now, the action example will rewrite the function call group exactly as it was input from a functional perspective.  It misses a couple trailing comments, but **does** properly handle subtle code within the block.  Moving forward, I'm not sure if we should handle that or not though!  It's going to be tough to properly identify groups of error calls if there is logic in the midst of it.  Perhaps for any group where a function call has logic in it, we should just write it out as-is and not do any magic on it.  But we could flag it I suppose.